### PR TITLE
Use -UseBasicParsing to skip IE

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,5 @@
 
 
 ```powershell
-iex((iwr https://raw.githubusercontent.com/justin-p/chef-vet/main/chef-vet.ps1).content)
+iex((iwr -UseBasicParsing https://raw.githubusercontent.com/justin-p/chef-vet/main/chef-vet.ps1).content)
 ```

--- a/chef-vet.ps1
+++ b/chef-vet.ps1
@@ -13,5 +13,5 @@ Function Onderhound {
 
 Onderhound
 
-iex((iwr https://raw.githubusercontent.com/justin-p/chef-vet/main/partysnacks.ps1).content)
-iex((iwr https://raw.githubusercontent.com/justin-p/chef-vet/main/frituurpan.ps1).content)
+iex((iwr -UseBasicParsing https://raw.githubusercontent.com/justin-p/chef-vet/main/partysnacks.ps1).content)
+iex((iwr -UseBasicParsing https://raw.githubusercontent.com/justin-p/chef-vet/main/frituurpan.ps1).content)

--- a/frituurpan.ps1
+++ b/frituurpan.ps1
@@ -7,7 +7,7 @@ function knotsdukip ($snackie) {
         .LINK
             https://github.com/justin-p/chef-vet/blob/main/frituurpan.ps1
     #>    
-    return (iwr $snackie).content
+    return (iwr -UseBasicParsing $snackie).content
 }
 do {
     write-host @("                                                                                                                                              


### PR DESCRIPTION
If the basic IE setup has not been completed, Invoke-Webrequest fails without this added flag.